### PR TITLE
Security fixes: prevent path traversal in `username` field, implement missing function-level access control in new account creation

### DIFF
--- a/Teachers_aide_server.py
+++ b/Teachers_aide_server.py
@@ -105,7 +105,7 @@ class Handler(BaseHTTPRequestHandler):
 		self.wfile.write(bytes(html, 'utf8'))
 
 
-	def set_cookie(self, username):
+	def set_cookie(self, username=''):
 		self.send_header('Set-Cookie', 'user={}; path=/; HTTPOnly'.format(username))
 		self.end_headers()
 
@@ -176,6 +176,10 @@ class Handler(BaseHTTPRequestHandler):
 
 		if form_input[0] == 'new_username':
 			username = os.path.basename(form_input[1].split('&')[0])
+			if os.path.exists(username + '.json'):
+				self.set_cookie()
+				self.load_new_profile()
+				return
 			password = form_input[2]
 			user_profile = TeacherProfile(username, password)
 			self.set_cookie(username)

--- a/Teachers_aide_server.py
+++ b/Teachers_aide_server.py
@@ -5,6 +5,7 @@ from jinja2 import Template
 
 import json
 import re
+import os
 
 from Test_creator import Test
 from Profile_creator import TeacherProfile
@@ -174,7 +175,7 @@ class Handler(BaseHTTPRequestHandler):
 		form_input = parse.unquote_plus(self.rfile.read(int(self.headers.get('content-length'))).decode('utf8')).split('=')
 
 		if form_input[0] == 'new_username':
-			username = form_input[1].split('&')[0]
+			username = os.path.basename(form_input[1].split('&')[0])
 			password = form_input[2]
 			user_profile = TeacherProfile(username, password)
 			self.set_cookie(username)
@@ -184,7 +185,7 @@ class Handler(BaseHTTPRequestHandler):
 
 		elif form_input[0] == 'username':
 			try:
-				username = form_input[1].split('&')[0]
+				username = os.path.basename(form_input[1].split('&')[0])
 				entered_password = form_input[2]
 				user_profile = self.decode_JSON(username)
 				if entered_password == user_profile.password:


### PR DESCRIPTION
First, this pull request is intended to be educational. I hope that it is. I briefly took a closer look at the server's code today and noticed a few important details that relate to the security of the application. Two issues I found were:

* A malicious user could write JSON files to arbitrary locations on the filesystem, possibly overwriting other JSON files and causing other servers/processes to fail or become misconfigured.
* A malicious, unauthenticated (logged out) user can delete the profile information (tests, passwords, etc.) of any other user in the system.

Neither of these abilities seem intentional so I'm assuming they are bugs. But the kind of bugs that they are happen to be security-related and thus serve as really good examples for highlighting how hard it is to write "secure" code.

# The path traversal vulnerability

The first bug, where a malicious user can write JSON files to arbitrary locations on the server's filesystem, is called a "path traversal" attack. It's called that because what the user does is supply a string that is interpreted by the code as a *path* instead of as a *single string value*.

In the case of this code specifically, the vulnerability exists in the `username` field in the "login" and "create new teacher profile" pages. In both HTML forms, the server is expecting that the user will type a *username*. However, if the user types a valid *path*, such as `../username`, then the server ends up creating a file called `username.json` in the directory *above* the server's own directory, because of the `../`, which as you know means "go up one level in the filesystem tree." An attacker can therefore use this function of your server to write JSON files to *any* arbitrary location on the filesystem, by entering the path to a directory where they want to write a given file relative to your server's current working directory.

For example, let's assume that your sever is run on a computer whose filesystem layout looks like this:

```
/
└── var/
    └── www/
        └── TeachersAideWebsite/
```

When a well-behaved user enters their "username," they might enter `alice` in the `username` field, and the result will be a filesystem tree like this:

```
/
└── var/
    └── www/
        └── TeachersAideWebsite/
            └── alice.json          <--- NEW FILE ADDED HERE
```

However, if an attacker comes along and enters `../new_user` as their "username," then the result will actually look like this:

```
/
└── var/
    └── www/
        ├── new_user.json           <--- ATTACKER'S FILE ADDED HERE, outside the server's directory
        └── TeachersAideWebsite/
            └── alice.json
```

This is clearly a problem, because you don't want random people on the Internet being able to write files anywhere on your disk that they please. To fix this, all you need to do is ensure that any code that is expecting to receive a single string value that will be treated as a filename later on takes *only* the filename portion of that path string, rather than the whole path. In Python, this can be accomplished by passing the string through [Python's `os.path.basename()` method](https://docs.python.org/3/library/os.path.html#os.path.basename). The fix is shown in commit 70aec85fdffca516f40ffd6d1d955a507e71021a.

Letting anonymous strangers write files anywhere they please on your disk might seem like more of a nuisance than a "security" vulnerability and, well, how severe that impact is really depends on what else is on the disk they can write to. But it can get really bad when combined with the second vulnerability, the missing function-level access control. Let's look at what is meant by that jargon-filled phrase, and then put it all together.

# The missing function-level access control vulnerability

The second relevant vulnerability is specifically a missing check to ensure that the server does not *overwrite* a JSON file that already exists when creating a new user profile. The "function" being referred to here is "the ability to create a new profile." The "access control" refers to the part of the code whose responsibility it is to ensure that only a given human individual who can successfully authenticate themselves to the system has permission to access the profile data associated with that human. In other words, if Alice has a profile (because she created one), then it should not be possible for Mallory to change Alice's profile data. Finally, the "missing" simply means that the code that should be doing that simply doesn't exist. It wasn't written.

In the specific manifestation of the problem in this server's code, one place the problem exists is on the "Create a new teacher profile" page. Any logged-out ("anonymous" or "unauthenticated") user can access this page. When they do, they're asked to enter a username and a password to create their profile. Once again, the `username` field is the vulnerable one.

The assumption in the code is that well-behaved users will choose their name. Alice would enter something like `alice` and Bob would enter something like `bob`. This results in two separate files: `alice.json` and `bob.json`. But a malicious user, Mallory, might *also* enter `alice`. When that happens, the server *deletes* Alice's profile information saved in `alice.json` and overwrites it with a new, blank profile. Not only does that action delete all of Alice's pre-existing saved tests, that new, blank profile now contains the password that the malicious user entered, meaning that the `alice` user account is now effectively under the control of the attacker because, when Alice returns and tries to login, she won't be able to. Her password will have been changed without her knowledge or permission.

That's certainly bad enough, but now let's put the two vulnerabilities together and see what else can happen.

# Chaining vulnerabilities to exploit other servers

Most computers don't just run one server. They run *many* servers at once. An actual filesystem has many, many files, and many of those are JSON files that are used to configure other servers. For instance, maybe the computer's filesystem looks more like this:

```
/
└── var/
    └── www/
        ├── other_server/           <--- NOTICE! Another server.
        │   └── other_servers_configuration_file.json    <--- And this server has a JSON configuration file
        ├── new_user.json           <--- ATTACKER'S FILE ADDED HERE, outside the server's directory
        └── TeachersAideWebsite/
            ├── alice.json
            └── bob.json
```

This poses an opportunity for an attacker because now, even if the other server's code is perfect, the ability of the TeachersAideWebsite server to overwrite JSON files means the attacker can overwrite the *other* server's configuration file. To do this, the attacker would navigate to the "Create a new teacher profile" page, and then enter `../other_server/other_servers_configuration_file` as their "username" on that page. The result of these form fields being submitted is that the TeachersAideWebsite server will *replace* the contents of the other server's JSON configuration with a new, empty teacher profile.

And that's *definitely* bad.

Both of these bad scenarios can be avoided by implementing the missing function-level access control, i.e., by having the server check if the file ("username") it was given already exists *before* writing to it when creating a new teacher profile. If it does already exist, don't overwrite it, because there's no legitimate reason for a user to be able to create a new teacher profile with the same name of an existing one. This can be checked using [Python's `os.path.exists()` method](https://docs.python.org/3/library/os.path.html#os.path.exists). The code that implements this check is shown in 29512971ac3bbec6594c6b88d6f9ec2cfe81529b.

I hope this was educational and demonstrates a real-life example both of how hard it is to write secure code, and for how serious (from a security perspective) relatively simple mistakes can be. I want to stress that these sorts of mistakes happen *all* the time, they're made by *very* experienced professionals frequently, and are not something for a relatively inexperienced programmer to feel embarrassed or ashamed about. In fact, these specific mistakes are *so* common that they are both on the [Open Web Application Security Project's (OWASP's) Top Ten lists since at least 2013](https://www.owasp.org/index.php/Top_10_2013-Top_10). *That's* how common they are.